### PR TITLE
`json_annotation`을 활용한 toJson 구현 및 `toInt()` 메소드 적용

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,19 +6,18 @@ environment:
   sdk: ">=2.13.0 <3.0.0"
 
 dependencies:
-  flutter:
-    sdk: flutter
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.3
+  flutter:
+    sdk: flutter
   get: ^4.6.0
+  iamport_flutter:
+    path: ../
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-  iamport_flutter:
-    path: ../
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec

--- a/lib/model/certification_data.g.dart
+++ b/lib/model/certification_data.g.dart
@@ -14,7 +14,7 @@ CertificationData _$CertificationDataFromJson(Map<String, dynamic> json) =>
       carrier: json['carrier'] as String?,
       name: json['name'] as String?,
       phone: json['phone'] as String?,
-      minAge: json['min_age'] as int?,
+      minAge: (json['min_age'] as num?)?.toInt(),
       popup: json['popup'] as bool?,
       mRedirectUrl: json['m_redirect_url'] as String?,
     );

--- a/lib/model/payment_data.g.dart
+++ b/lib/model/payment_data.g.dart
@@ -16,8 +16,8 @@ PaymentData _$PaymentDataFromJson(Map<String, dynamic> json) => PaymentData(
       customData: (json['custom_data'] as Map<String, dynamic>?)?.map(
         (k, e) => MapEntry(k, e as String),
       ),
-      taxFree: json['tax_free'] as int?,
-      vat: json['vat'] as int?,
+      taxFree: (json['tax_free'] as num?)?.toInt(),
+      vat: (json['vat'] as num?)?.toInt(),
       currency: json['currency'] as String?,
       language: json['language'] as String?,
       buyerName: json['buyer_name'] as String?,
@@ -27,7 +27,8 @@ PaymentData _$PaymentDataFromJson(Map<String, dynamic> json) => PaymentData(
       buyerPostcode: json['buyer_postcode'] as String?,
       noticeUrl: json['notice_url'] as String?,
       cardQuota: PaymentData._cardQuotaFromJson(
-          json['display'] as Map<String, dynamic>),
+        json['display'] as Map<String, dynamic>,
+      ),
       digital: json['digital'] as bool?,
       vbankDue: json['vbank_due'] as String?,
       confirmUrl: json['confirm_url'] as String?,
@@ -52,7 +53,8 @@ PaymentData _$PaymentDataFromJson(Map<String, dynamic> json) => PaymentData(
       naverInterface: json['naverInterface'] == null
           ? null
           : NaverInterface.fromJson(
-              json['naverInterface'] as Map<String, dynamic>),
+              json['naverInterface'] as Map<String, dynamic>,
+            ),
       period: (json['period'] as Map<String, dynamic>?)?.map(
         (k, e) => MapEntry(k, e as String),
       ),

--- a/lib/model/pg/daou/daou.g.dart
+++ b/lib/model/pg/daou/daou.g.dart
@@ -8,7 +8,7 @@ part of 'daou.dart';
 
 Daou _$DaouFromJson(Map<String, dynamic> json) => Daou(
       productCode: json['PRODUCTCODE'] as String?,
-      cashReceiptFlag: json['CASHRECEIPTFLAG'] as int,
+      cashReceiptFlag: (json['CASHRECEIPTFLAG'] as num).toInt(),
     );
 
 Map<String, dynamic> _$DaouToJson(Daou instance) {

--- a/lib/model/pg/kcp/kcp_products.g.dart
+++ b/lib/model/pg/kcp/kcp_products.g.dart
@@ -9,8 +9,8 @@ part of 'kcp_products.dart';
 KcpProducts _$KcpProductsFromJson(Map<String, dynamic> json) => KcpProducts(
       orderNumber: json['orderNumber'] as String,
       name: json['name'] as String,
-      quantity: json['quantity'] as int,
-      amount: json['amount'] as int,
+      quantity: (json['quantity'] as num).toInt(),
+      amount: (json['amount'] as num).toInt(),
     );
 
 Map<String, dynamic> _$KcpProductsToJson(KcpProducts instance) =>

--- a/lib/model/pg/naver/naver_co_products.g.dart
+++ b/lib/model/pg/naver/naver_co_products.g.dart
@@ -12,9 +12,9 @@ NaverCoProducts _$NaverCoProductsFromJson(Map<String, dynamic> json) =>
       merchantProductId: json['merchantProductId'] as String?,
       ecMallProductId: json['ecMallProductId'] as String?,
       name: json['name'] as String?,
-      basePrice: json['basePrice'] as int?,
+      basePrice: (json['basePrice'] as num?)?.toInt(),
       taxType: json['taxType'] as String?,
-      quantity: json['quantity'] as int?,
+      quantity: (json['quantity'] as num?)?.toInt(),
       infoUrl: json['infoUrl'] as String?,
       imageUrl: json['imageUrl'] as String?,
       giftName: json['giftName'] as String?,
@@ -56,8 +56,8 @@ Map<String, dynamic> _$NaverCoProductsToJson(NaverCoProducts instance) {
 
 NaverCoOption _$NaverCoOptionFromJson(Map<String, dynamic> json) =>
     NaverCoOption(
-      optionQuantity: json['optionQuantity'] as int?,
-      optionPrice: json['optionPrice'] as int?,
+      optionQuantity: (json['optionQuantity'] as num?)?.toInt(),
+      optionPrice: (json['optionPrice'] as num?)?.toInt(),
       selectionCode: json['selectionCode'] as String?,
       selections: (json['selections'] as List<dynamic>?)
           ?.map((e) => NaverCoOptionItem.fromJson(e as Map<String, dynamic>))
@@ -106,8 +106,8 @@ NaverCoSupplement _$NaverCoSupplementFromJson(Map<String, dynamic> json) =>
     NaverCoSupplement(
       id: json['id'] as String?,
       name: json['name'] as String?,
-      price: json['price'] as int?,
-      quantity: json['quantity'] as int?,
+      price: (json['price'] as num?)?.toInt(),
+      quantity: (json['quantity'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$NaverCoSupplementToJson(NaverCoSupplement instance) {
@@ -130,7 +130,7 @@ NaverCoShipping _$NaverCoShippingFromJson(Map<String, dynamic> json) =>
     NaverCoShipping(
       groupId: json['groupId'] as String?,
       method: json['method'] as String?,
-      baseFee: json['baseFee'] as int?,
+      baseFee: (json['baseFee'] as num?)?.toInt(),
       feePayType: json['feePayType'] as String?,
       feeRule: json['feeRule'] == null
           ? null
@@ -156,8 +156,8 @@ Map<String, dynamic> _$NaverCoShippingToJson(NaverCoShipping instance) {
 
 NaverCoFeeRule _$NaverCoFeeRuleFromJson(Map<String, dynamic> json) =>
     NaverCoFeeRule(
-      freeByThreshold: json['freeByThreshold'] as int?,
-      repeatByQty: json['repeatByQty'] as int?,
+      freeByThreshold: (json['freeByThreshold'] as num?)?.toInt(),
+      repeatByQty: (json['repeatByQty'] as num?)?.toInt(),
       rangesByQty: (json['rangesByQty'] as List<dynamic>?)
           ?.map((e) => NaverCoFeeRangeByQty.fromJson(e as Map<String, dynamic>))
           .toList(),
@@ -183,14 +183,16 @@ Map<String, dynamic> _$NaverCoFeeRuleToJson(NaverCoFeeRule instance) {
 }
 
 NaverCoFeeRangeByQty _$NaverCoFeeRangeByQtyFromJson(
-        Map<String, dynamic> json) =>
+  Map<String, dynamic> json,
+) =>
     NaverCoFeeRangeByQty(
-      from: json['from'] as int?,
-      surcharge: json['surcharge'] as int?,
+      from: (json['from'] as num?)?.toInt(),
+      surcharge: (json['surcharge'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$NaverCoFeeRangeByQtyToJson(
-    NaverCoFeeRangeByQty instance) {
+  NaverCoFeeRangeByQty instance,
+) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -207,7 +209,7 @@ Map<String, dynamic> _$NaverCoFeeRangeByQtyToJson(
 NaverCoFeeAreaByQty _$NaverCoFeeAreaByQtyFromJson(Map<String, dynamic> json) =>
     NaverCoFeeAreaByQty(
       from: (json['from'] as List<dynamic>?)?.map((e) => e as String).toList(),
-      surcharge: json['surcharge'] as int?,
+      surcharge: (json['surcharge'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$NaverCoFeeAreaByQtyToJson(NaverCoFeeAreaByQty instance) {

--- a/lib/model/pg/naver/naver_pay_products.g.dart
+++ b/lib/model/pg/naver/naver_pay_products.g.dart
@@ -12,7 +12,7 @@ NaverPayProducts _$NaverPayProductsFromJson(Map<String, dynamic> json) =>
       categoryId: json['categoryId'] as String,
       uid: json['uid'] as String,
       name: json['name'] as String,
-      count: json['count'] as int,
+      count: (json['count'] as num).toInt(),
       payReferrer: json['payReferrer'] as String?,
     );
 

--- a/lib/model/pg/naver/naver_products.dart
+++ b/lib/model/pg/naver/naver_products.dart
@@ -15,4 +15,6 @@ abstract class NaverProducts {
       return NaverPayProducts.fromJson(json);
     }
   }
+
+  Map<String, dynamic> toJson() => _$NaverProductsToJson(this);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,21 +4,21 @@ version: 0.10.19
 homepage: https://github.com/iamport/iamport_flutter
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: ">=2.17.0 <4.0.0"
   flutter: ">=2.5.0"
 
 dependencies:
+  app_links: ^6.1.1
   flutter:
     sdk: flutter
   iamport_webview_flutter: 3.0.7
-  url_launcher: ^6.0.4
-  app_links: ^6.1.1
   json_annotation: ^4.8.1
+  url_launcher: ^6.0.4
 
 dev_dependencies:
-  test: ^1.19.0
   build_runner: ^2.0.0
   json_serializable: ^6.7.1
+  test: ^1.19.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec


### PR DESCRIPTION
### 내용
- `json_annotation`에 의해 생성된 `toJson` 메소드를 클래스에서 사용하지 않은 부분을 발견하여 수정했습니다.
- `lib/model` 디렉토리 하위의 클래스들에 `json_annotation`의 최신 버전에서 지원하는 `toInt()` 메소드를 적용하여 코드를 업데이트했습니다.

### 참고
- 해당 변경사항은 JSON 직렬화와 관련된 버그를 방지하고, 최신 기능을 활용하기 위한 업데이트입니다.
