### PR TITLE
[SPT-4021] Add channelKey field to PaymentData for V1 SDK

### DIFF
--- a/lib/model/payment_data.dart
+++ b/lib/model/payment_data.dart
@@ -9,7 +9,8 @@ part 'payment_data.g.dart';
 
 @JsonSerializable()
 class PaymentData {
-  String? pg; // PG사
+  String? pg; // PG사 (지원 중단 예정, channelKey 사용 권장)
+  String? channelKey; // 채널키 (pg 대체)
 
   @JsonKey(name: 'pay_method')
   String payMethod; // 결제수단
@@ -100,6 +101,7 @@ class PaymentData {
 
   PaymentData({
     this.pg,
+    this.channelKey,
     required this.payMethod,
     this.escrow,
     required this.merchantUid,

--- a/lib/model/payment_data.g.dart
+++ b/lib/model/payment_data.g.dart
@@ -8,6 +8,7 @@ part of 'payment_data.dart';
 
 PaymentData _$PaymentDataFromJson(Map<String, dynamic> json) => PaymentData(
       pg: json['pg'] as String?,
+      channelKey: json['channelKey'] as String?,
       payMethod: json['pay_method'] as String,
       escrow: json['escrow'] as bool?,
       merchantUid: json['merchant_uid'] as String,
@@ -76,6 +77,7 @@ Map<String, dynamic> _$PaymentDataToJson(PaymentData instance) {
   }
 
   writeNotNull('pg', instance.pg);
+  writeNotNull('channelKey', instance.channelKey);
   val['pay_method'] = instance.payMethod;
   writeNotNull('escrow', instance.escrow);
   val['merchant_uid'] = instance.merchantUid;


### PR DESCRIPTION
## Summary
- `PaymentData`에 `channelKey` 필드 추가 (포트원 v1 JS SDK의 채널키 지원)
- 기존 `pg` 파라미터는 포트원 v1 JS SDK에서 deprecated 예정으로, `channelKey`가 권장 방식으로 전환됨
- `pg`와 `channelKey`는 동시에 사용 가능하며, `channelKey`만 사용하는 경우에도 동작함

## 참고사항
- `channelKey`만 사용 시 Flutter 레이어의 PG별 특수 처리 로직(`customPGAction`)이 동작하지 않는 케이스 존재
  - 스마일페이 → Android 서드파티 쿠키 설정 누락
  - 나이스 계좌이체 (`trans`) → 뱅크페이 앱 딥링크 처리 누락
  - 이니시스 계좌이체 (`trans`) → iOS 결제 완료 감지 누락
- 위 PG를 `channelKey`로 사용하는 경우 `pg` 파라미터를 병행 전달하거나 별도 대응 필요

## Test plan
- [ ] `channelKey`만 전달해서 결제 요청 시 JS SDK로 정상 전달되는지 확인
- [ ] `pg` + `channelKey` 동시 전달 시 기존 동작 유지 확인
- [ ] `channelKey` 없이 기존 `pg`만 사용하는 기존 코드에 영향 없는지 확인

[SPT-4021]: https://riiid-pioneer.atlassian.net/browse/SPT-4021

Made with [Cursor](https://cursor.com)